### PR TITLE
New logos/colors for Top Merchants

### DIFF
--- a/components/Wrapped/slides/HCBTopMerchants.tsx
+++ b/components/Wrapped/slides/HCBTopMerchants.tsx
@@ -18,22 +18,20 @@ const additionalData: {
   },
   AMAZON: {
     image: "https://wisdom-stone.com/wp-content/uploads/amazon-logo.png",
-    color: $.orange
+    color: $.steel
   },
   "STICKER MULE": {
     image:
       "https://cdn.icon-icons.com/icons2/2699/PNG/512/stickermule_logo_icon_169715.png",
+    color: $.stickermule
+  },
+  "FIRST FOR INSPIRATION & R": {
+    image: "https://cloud-6ik9jo5u6-hack-club-bot.vercel.app/0image.png",
     color: $.red
   },
-  "KIT LENDER": {
-    image:
-      "https://cloud-4jlvg7r0t-hack-club-bot.vercel.app/0screenshot_2023-12-15_at_12.40.20___am.png",
-    color: $.green
-  },
-  "PREMIER COACH COMPANY INC": {
-    image:
-      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Bus-logo.svg/2048px-Bus-logo.svg.png",
-    color: $.muted
+  "REVROBOTICS": {
+    image: "https://cloud-161bscnw9-hack-club-bot.vercel.app/0image.png",
+    color: $.orange
   }
 };
 

--- a/utils/theme.tsx
+++ b/utils/theme.tsx
@@ -38,6 +38,7 @@ const themeUtils = {
   twitter: "#1da1f2",
   facebook: "#3b5998",
   instagram: "#e1306c",
+  stickermule: "#492A1A",
   createComponent(element: string, styles?: CSSProperties) {
     // @ts-ignore
     const { classes } = this;


### PR DESCRIPTION
It seems like the top merchants we "planned" for are now incorrect.

BEFORE
<img width="491" alt="image" src="https://github.com/hackclub/hcb-wrapped-2023/assets/20099646/c047a005-da2e-4922-be55-ea69306d215d">


AFTER
<img width="497" alt="image" src="https://github.com/hackclub/hcb-wrapped-2023/assets/20099646/2656342c-318d-4782-98e3-b814fb9ff7f4">
