### PR TITLE
HCB: Add caption to map

### DIFF
--- a/components/Wrapped/slides/HCB.tsx
+++ b/components/Wrapped/slides/HCB.tsx
@@ -65,7 +65,12 @@ export default function HCB({ data }: SlideProps) {
             isNumber
             prefix="$"
           />
-          <img src="https://cloud-q1u33t4vk-hack-club-bot.vercel.app/0amount.png" style={{borderRadius: '12px'}} />
+          <div style={{position: "relative"}}>
+            <img src="https://cloud-q1u33t4vk-hack-club-bot.vercel.app/0amount.png" style={{borderRadius: '12px'}} />
+            <span style={{position: "absolute", bottom: "10px", right: "10px"}}>
+              Popular spending locations
+            </span>
+          </div>
         </div>
         <div
           {...$({

--- a/components/Wrapped/slides/HCB.tsx
+++ b/components/Wrapped/slides/HCB.tsx
@@ -67,7 +67,7 @@ export default function HCB({ data }: SlideProps) {
           />
           <div style={{position: "relative"}}>
             <img src="https://cloud-q1u33t4vk-hack-club-bot.vercel.app/0amount.png" style={{borderRadius: '12px'}} />
-            <span style={{position: "absolute", bottom: "10px", right: "10px"}}>
+            <span style={{position: "absolute", bottom: "10px", right: "10px", textTransform: 'uppercase', color: $.muted, fontStyle: 'italic'}}>
               Popular spending locations
             </span>
           </div>


### PR DESCRIPTION
I assume this is a map of spending location by zipcode. Please correct the caption if this is incorrect!

<img width="507" alt="image" src="https://github.com/hackclub/hcb-wrapped-2023/assets/20099646/dc29fc2c-a306-49d9-986b-69f609c71ac1">
