### PR TITLE
Fix spending ranking

### DIFF
--- a/components/Wrapped/slides/Spender.tsx
+++ b/components/Wrapped/slides/Spender.tsx
@@ -7,6 +7,11 @@ import CountUp from "react-countup";
 import { prettifyCategory } from "./HCBTopMerchants";
 
 export default function Spender({ data }: SlideProps) {
+  const roundTo2 = (decimal: number) =>
+    (Math.round((decimal + Number.EPSILON) * 100 * 100) / 100);
+  const percentile = roundTo2(1 - data.individual.ranking);
+  const ranking = roundTo2(data.individual.ranking);
+
   return (
     <>
       <h2 {...$.title({ marginBottom: $.s3 })}>💳</h2>
@@ -57,12 +62,21 @@ export default function Spender({ data }: SlideProps) {
           )} with them.`}
           background={$.blue}
         />
-        <HCBStat
-          topLabel="You spent more than"
-          data={100 - data.individual.ranking + "%"}
-          label="of other HCB users!"
-          background={$.green}
-        />
+        {data.individual.ranking <= 0.07 ? ( // Top 7% of spenders
+          <HCBStat
+            topLabel="Congrats! You're one of the top"
+            data={ranking + "%"}
+            label="of spenders!"
+            background={$.green}
+          />
+        ) : (
+          <HCBStat
+            topLabel="You spent more than"
+            data={percentile + "%"}
+            label="of other HCB users!"
+            background={$.green}
+          />
+        )}
       </div>
       <Background />
     </>


### PR DESCRIPTION
There are two views.

User who spent a lot:
<img width="454" alt="image" src="https://github.com/hackclub/hcb-wrapped-2023/assets/20099646/2daca26b-6324-45cc-8004-53b644d7b7e3">

Other users:
<img width="458" alt="image" src="https://github.com/hackclub/hcb-wrapped-2023/assets/20099646/2589824f-a894-4b4f-b487-e7a1c38436f1">

There is an associated fix here: https://github.com/hackclub/hcb/pull/4781